### PR TITLE
Link mapping support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,22 +1,5 @@
-=============================
-sphinxcontrib-serializinghtml
-=============================
+This is a fork of https://github.com/sphinx-doc/sphinxcontrib-serializinghtml
 
-sphinxcontrib-serializinghtml is a sphinx extension which outputs
-"serialized" HTML files (json and pickle).
+Changes made to this fork are to facilitate the creation of JSON files suitable for consumption by React.
 
-For more details, please visit http://www.sphinx-doc.org/.
-
-Installing
-==========
-
-Install from PyPI::
-
-   pip install -U sphinxcontrib-serializinghtml
-
-Contributing
-============
-
-See `CONTRIBUTING.rst`__
-
-.. __: https://github.com/sphinx-doc/sphinx/blob/master/CONTRIBUTING.rst
+Since those changes are very specific, they have not been contributed back to the original repo.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
     "Topic :: Text Processing",
     "Topic :: Utilities",
 ]
-dependencies = []
+dependencies = ["beautifulsoup4"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-240904'
+__version__ = '2.0.0+Linaro-240904a'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -83,15 +83,11 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.use_index = self.get_builder_config('use_index', 'html')
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
-        # For the Solutions Hub, we want all URIs to be absolute. They will
-        # all be /library/<project_name>/<docname> except that "index" will
-        # get trimmed off
-        project_name = self.get_builder_config('project_name', 'html')
         if docname == 'index':
-            return f"/library/{project_name}/{project_name}"
+            return "/"
         if docname.endswith(SEP + 'index'):
-            return f"/library/{project_name}/{docname[:-5]}"  # up to sep
-        return f"/library/{project_name}/{docname}"
+            return f"/{docname[:-5]}"  # up to sep
+        return f"/{docname}"
 
     def dump_context(self, context: dict[str, Any], filename: str | os.PathLike[str]) -> None:
         context = context.copy()

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro'
+__version__ = '2.0.0+Linaro-240806'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))
@@ -83,11 +83,16 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.use_index = self.get_builder_config('use_index', 'html')
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
+        print(f"get_target_uri: {docname}")
+        # For the Solutions Hub, we want all URIs to be absolute. They will
+        # all be /library/<project_name>/<docname> except that "index" will
+        # get trimmed off
+        project_name = self.get_builder_config('project_name', 'html')
         if docname == 'index':
-            return ''
+            return f"/library/{project_name}/{project_name}"
         if docname.endswith(SEP + 'index'):
-            return docname[:-5]  # up to sep
-        return docname + SEP
+            return f"/library/{project_name}/{docname[:-5]}"  # up to sep
+        return f"/library/{project_name}/{docname}"
 
     def dump_context(self, context: dict[str, Any], filename: str | os.PathLike[str]) -> None:
         context = context.copy()

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-240904a'
+__version__ = '2.0.0+Linaro-240904b'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-240904b'
+__version__ = '2.0.0+Linaro-241024'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))
@@ -104,6 +104,7 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
 
     def handle_page(self, pagename: str, ctx: dict[str, Any], templatename: str = 'page.html',
                     outfilename: str | None = None, event_arg: Any = None) -> None:
+        print(f"handle_page: {pagename}")
         ctx['current_page_name'] = pagename
         ctx.setdefault('pathto', lambda p: p)
         self.add_sidebars(pagename, ctx)
@@ -136,12 +137,16 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
             if isinstance(ctx[key], types.FunctionType):
                 del ctx[key]
 
-        # PJC: Some Linaro documentation has encoded attributes in image ALT text
-        # which then gets decoded when the HTML is loaded into the DOM, so
-        # we need to alter it by "escaping" the ampersands with &amp; to
-        # prevent the decoding.
         if "body" in ctx:
+            # PJC: Some Linaro documentation has encoded attributes in image ALT text
+            # which then gets decoded when the HTML is loaded into the DOM, so
+            # we need to alter it by "escaping" the ampersands with &amp; to
+            # prevent the decoding.
             ctx['body'] = html_assists.escape_encoded_alt_text(ctx['body'])
+            # PJC: Furthermore, if there is any formatted code with encoded attributes,
+            # e.g. < changed to &lt; then that also needs to be escaped because it is
+            # also getting decoded.
+            ctx['body'] = html_assists.escape_encoded_pre_text(ctx['body'])
 
         ensuredir(path.dirname(outfilename))
         self.dump_context(ctx, outfilename)

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -55,7 +55,24 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
 
     def init(self) -> None:
         self.build_info = BuildInfo(self.config, self.tags)
-        self.imagedir = '_images'
+        # Cope with whether or not Sphinx has the required configuration variables
+        # set.
+        # See HTML Builder comments for explanation of image setup & handling
+        html_image_dir = None
+        try:
+            html_image_dir = self.get_builder_config('image_dir', 'html')
+        except AttributeError:
+            pass
+        if html_image_dir is not None:
+            self.imagedir = html_image_dir
+        else:
+            self.imagedir = '_images'
+        html_image_path = None
+        try:
+            html_image_path = self.get_builder_config('image_path', 'html')
+        except AttributeError:
+            pass
+        self.imagepath = html_image_path
         self.current_docname = ''
         self.theme = None  # type: ignore[assignment] # no theme necessary
         self.templates = None  # no template bridge necessary

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0'
+__version__ = '2.0.0+Linaro'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -83,7 +83,6 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.use_index = self.get_builder_config('use_index', 'html')
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
-        print(f"get_target_uri: {docname}")
         # For the Solutions Hub, we want all URIs to be absolute. They will
         # all be /library/<project_name>/<docname> except that "index" will
         # get trimmed off

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-240807'
+__version__ = '2.0.0+Linaro-240904'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-241024'
+__version__ = '2.0.0+Linaro-241024a'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -104,6 +104,7 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
                     page_filename = self.get_builder_config('project_name', 'html')
                 else:
                     page_filename = SEP.join(parts[:-1])
+                ctx['current_page_name'] = page_filename
             else:
                 page_filename = pagename
             outfilename = path.join(self.outdir,

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -81,6 +81,15 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
         self.init_css_files()
         self.init_js_files()
         self.use_index = self.get_builder_config('use_index', 'html')
+        #
+        # PJC: New configuration to allow mapping of external links to
+        # relative Hub links.
+        link_mappings = None
+        try:
+            link_mappings = self.get_builder_config('link_mappings', 'html')
+        except AttributeError:
+            pass
+        self.link_mappings = link_mappings
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
         if docname == 'index':
@@ -146,6 +155,9 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
             # e.g. < changed to &lt; then that also needs to be escaped because it is
             # also getting decoded.
             ctx['body'] = html_assists.escape_encoded_pre_text(ctx['body'])
+            # PJC: Go through the body, looking for any <a> tags to see if they
+            # need to be re-mapped to a local Hub path.
+            ctx['body'] = html_assists.rewrite_hub_links(ctx['body'], self.link_mappings)
 
         ensuredir(path.dirname(outfilename))
         self.dump_context(ctx, outfilename)

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -84,10 +84,10 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
 
     def get_target_uri(self, docname: str, typ: str | None = None) -> str:
         if docname == 'index':
-            return "/"
+            return ""
         if docname.endswith(SEP + 'index'):
-            return f"/{docname[:-5]}"  # up to sep
-        return f"/{docname}"
+            return docname[:-5]  # up to sep
+        return docname
 
     def dump_context(self, context: dict[str, Any], filename: str | os.PathLike[str]) -> None:
         context = context.copy()

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-241024a'
+__version__ = '2.0.0+Linaro-241028'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))
@@ -104,7 +104,6 @@ class SerializingHTMLBuilder(StandaloneHTMLBuilder):
 
     def handle_page(self, pagename: str, ctx: dict[str, Any], templatename: str = 'page.html',
                     outfilename: str | None = None, event_arg: Any = None) -> None:
-        print(f"handle_page: {pagename}")
         ctx['current_page_name'] = pagename
         ctx.setdefault('pathto', lambda p: p)
         self.add_sidebars(pagename, ctx)

--- a/sphinxcontrib/serializinghtml/__init__.py
+++ b/sphinxcontrib/serializinghtml/__init__.py
@@ -23,7 +23,7 @@ if TYPE_CHECKING:
         def load(self, file: Any, *args: Any, **kwargs: Any) -> Any: ...
         def loads(self, data: Any, *args: Any, **kwargs: Any) -> Any: ...
 
-__version__ = '2.0.0+Linaro-240806'
+__version__ = '2.0.0+Linaro-240807'
 __version_info__ = (2, 0, 0)
 
 package_dir = path.abspath(path.dirname(__file__))

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -48,6 +48,7 @@ def process_section(result, child, section, pending_divider) -> bool:
             result.append({ "type": "divider" })
             pending_divider = False
         result.append(convert_tag_to_link(child))
+    return pending_divider
 
 def process_ul_children(result, ul):
     pending_divider = False

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -108,3 +108,20 @@ def escape_encoded_pre_text(html: str) -> str:
     if edited:
         html = str(soup)
     return html
+
+def rewrite_hub_links(html: str, link_mappings: dict) -> str:
+    edited = False
+    soup = BeautifulSoup(html, "html.parser")
+    links = soup.find_all('a')
+    for link in links:
+        for key in link_mappings:
+            if link['href'].startswith(key):
+                # We have a match, so replace the href with the new one
+                link['href'] = link['href'].replace(key, link_mappings[key])
+                # We also have to remove ".html" from the end of the link
+                link['href'] = link['href'].replace(".html", "")
+                edited = True
+
+    if edited:
+        html = str(soup)
+    return html

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -91,18 +91,22 @@ def escape_encoded_alt_text(html: str) -> str:
         html = str(soup)
     return html
 
+def matched_pre(span) -> bool:
+    """ Check if this span is specifying the "pre" class """
+    if "class" not in span:
+        return False
+    classes = span["class"]
+    for this_class in classes:
+        if this_class == "pre":
+            return True
+    return False
+
 def escape_encoded_pre_text(html: str) -> str:
-    print("escape_encoded_pre_text")
     edited = False
     soup = BeautifulSoup(html, "html.parser")
     spans = soup.find_all('span')
     for span in spans:
-        classes = span["class"]
-        matched_pre = False
-        for this_class in classes:
-            if this_class == "pre":
-                matched_pre = True
-        if matched_pre:
+        if matched_pre(span):
             # At this point, Beautiful Soup has done what a browser does - decode
             # any encoded attributes. So we need to re-encode the string, see if
             # there are any ampersands and, if so, re-encode them again.
@@ -113,5 +117,4 @@ def escape_encoded_pre_text(html: str) -> str:
 
     if edited:
         html = str(soup)
-        print(html)
     return html

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -1,6 +1,6 @@
 from bs4 import BeautifulSoup, element
-import json
 import sys
+from html import escape
 
 def clean_href(href: str) -> str:
     """ Make sure the href doesn't start or end with a / """
@@ -31,6 +31,20 @@ def convert_tag_to_link(item_entry: element.Tag) -> dict:
             "text": a_tag.contents[0],
             "href": clean_href(a_tag["href"])
         }
+
+def escape_encoded_alt_text(html: str) -> str:
+    soup = BeautifulSoup(html, "html.parser")
+    images = soup.find_all('img')
+    for img in images:
+        if img['alt'] != "":
+            # At this point, Beautiful Soup has done what a browser does - decode
+            # any encoded attributes. So we need to re-encode the string, see if
+            # there are any ampersands and, if so, re-encode them again.
+            interim = escape(img['alt'])
+            if interim.find("&") != -1:
+                img['alt'] = escape(interim)
+
+    return html
 
 def convert_nav_html_to_json(html: str) -> list:
     result = []

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -22,7 +22,6 @@ def section_links(parent_entry: element.Tag, list_entry: element.Tag) -> dict:
                 "items": section_result
             }
 
-
 def convert_tag_to_link(item_entry: element.Tag) -> dict:
     # The a tag is a child of the li tag
     a_tag = item_entry.contents[0]
@@ -31,6 +30,48 @@ def convert_tag_to_link(item_entry: element.Tag) -> dict:
             "text": a_tag.contents[0],
             "href": clean_href(a_tag["href"])
         }
+
+def process_section(result, child, section, pending_divider) -> bool:
+    if section != []:
+                # Yes, there is, so we have a sub-section. If we've got some content
+                # already, add a divider.
+        if result != []:
+            result.append({ "type": "divider" })
+                # Now append the current page and the section links. The
+                # ul tag is the only child returned, hence [0]
+        result.append(section_links(child, section[0]))
+                # If there are any "normal" entries after this section
+                # add a divider first
+        pending_divider = True
+    else:
+        if pending_divider:
+            result.append({ "type": "divider" })
+            pending_divider = False
+        result.append(convert_tag_to_link(child))
+
+def process_ul_children(result, ul):
+    pending_divider = False
+    for child in ul.children:
+        if type(child) is element.Tag and child.name == "li":
+            # Is there a new unordered list within this section?
+            section = child.find_all("ul", limit=1)
+            pending_divider = process_section(result, child, section, pending_divider)
+
+def convert_nav_html_to_json(html: str) -> list:
+    result = []
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Start with the unordered list
+    ul = soup.ul
+    # Iterate through list items
+    while ul is not None:
+        process_ul_children(result, ul)
+        while True:
+            ul = ul.next_sibling
+            if ul is None or type(ul) is element.Tag:
+                break
+            # Not an acceptable type - loop and get the next sibling
+    return result
 
 def escape_encoded_alt_text(html: str) -> str:
     edited = False
@@ -50,38 +91,27 @@ def escape_encoded_alt_text(html: str) -> str:
         html = str(soup)
     return html
 
-def convert_nav_html_to_json(html: str) -> list:
-    result = []
+def escape_encoded_pre_text(html: str) -> str:
+    print("escape_encoded_pre_text")
+    edited = False
     soup = BeautifulSoup(html, "html.parser")
+    spans = soup.find_all('span')
+    for span in spans:
+        classes = span["class"]
+        matched_pre = False
+        for this_class in classes:
+            if this_class == "pre":
+                matched_pre = True
+        if matched_pre:
+            # At this point, Beautiful Soup has done what a browser does - decode
+            # any encoded attributes. So we need to re-encode the string, see if
+            # there are any ampersands and, if so, re-encode them again.
+            interim = escape(span.string)
+            if interim.find("&") != -1:
+                span.string = escape(interim)
+                edited = True
 
-    # Start with the unordered list
-    ul = soup.ul
-    pending_divider = False
-    # Iterate through list items
-    while ul is not None:
-        for child in ul.children:
-            if type(child) is element.Tag and child.name == "li":
-                # Is there a new unordered list within this section?
-                section = child.find_all("ul", limit=1)
-                if section != []:
-                    # Yes, there is, so we have a sub-section. If we've got some content
-                    # already, add a divider.
-                    if result != []:
-                        result.append({ "type": "divider" })
-                    # Now append the current page and the section links. The
-                    # ul tag is the only child returned, hence [0]
-                    result.append(section_links(child, section[0]))
-                    # If there are any "normal" entries after this section
-                    # add a divider first
-                    pending_divider = True
-                else:
-                    if pending_divider:
-                        result.append({ "type": "divider" })
-                        pending_divider = False
-                    result.append(convert_tag_to_link(child))
-        while True:
-            ul = ul.next_sibling
-            if ul is None or type(ul) is element.Tag:
-                break
-            # Not an acceptable type - loop and get the next sibling
-    return result
+    if edited:
+        html = str(soup)
+        print(html)
+    return html

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -91,29 +91,18 @@ def escape_encoded_alt_text(html: str) -> str:
         html = str(soup)
     return html
 
-def matched_pre(span) -> bool:
-    """ Check if this span is specifying the "pre" class """
-    if "class" not in span:
-        return False
-    classes = span["class"]
-    for this_class in classes:
-        if this_class == "pre":
-            return True
-    return False
-
 def escape_encoded_pre_text(html: str) -> str:
     edited = False
     soup = BeautifulSoup(html, "html.parser")
-    spans = soup.find_all('span')
+    spans = soup.find_all('span', class_="pre")
     for span in spans:
-        if matched_pre(span):
-            # At this point, Beautiful Soup has done what a browser does - decode
-            # any encoded attributes. So we need to re-encode the string, see if
-            # there are any ampersands and, if so, re-encode them again.
-            interim = escape(span.string)
-            if interim.find("&") != -1:
-                span.string = escape(interim)
-                edited = True
+        # At this point, Beautiful Soup has done what a browser does - decode
+        # any encoded attributes. So we need to re-encode the string, see if
+        # there are any ampersands and, if so, re-encode them again.
+        interim = escape(span.string)
+        if interim.find("&") != -1:
+            span.string = escape(interim)
+            edited = True
 
     if edited:
         html = str(soup)

--- a/sphinxcontrib/serializinghtml/html_assists.py
+++ b/sphinxcontrib/serializinghtml/html_assists.py
@@ -33,6 +33,7 @@ def convert_tag_to_link(item_entry: element.Tag) -> dict:
         }
 
 def escape_encoded_alt_text(html: str) -> str:
+    edited = False
     soup = BeautifulSoup(html, "html.parser")
     images = soup.find_all('img')
     for img in images:
@@ -43,7 +44,10 @@ def escape_encoded_alt_text(html: str) -> str:
             interim = escape(img['alt'])
             if interim.find("&") != -1:
                 img['alt'] = escape(interim)
+                edited = True
 
+    if edited:
+        html = str(soup)
     return html
 
 def convert_nav_html_to_json(html: str) -> list:

--- a/sphinxcontrib/serializinghtml/nav_html_to_json.py
+++ b/sphinxcontrib/serializinghtml/nav_html_to_json.py
@@ -1,5 +1,6 @@
 from bs4 import BeautifulSoup, element
 import json
+import sys
 
 def clean_href(href: str) -> str:
     """ Make sure the href doesn't start or end with a / """
@@ -39,7 +40,7 @@ def convert_nav_html_to_json(html: str) -> list:
     ul = soup.ul
     pending_divider = False
     # Iterate through list items
-    if ul is not None:
+    while ul is not None:
         for child in ul.children:
             if type(child) is element.Tag and child.name == "li":
                 # Is there a new unordered list within this section?
@@ -60,4 +61,9 @@ def convert_nav_html_to_json(html: str) -> list:
                         result.append({ "type": "divider" })
                         pending_divider = False
                     result.append(convert_tag_to_link(child))
+        while True:
+            ul = ul.next_sibling
+            if ul is None or type(ul) is element.Tag:
+                break
+            # Not an acceptable type - loop and get the next sibling
     return result

--- a/sphinxcontrib/serializinghtml/nav_html_to_json.py
+++ b/sphinxcontrib/serializinghtml/nav_html_to_json.py
@@ -1,6 +1,14 @@
 from bs4 import BeautifulSoup, element
 import json
 
+def clean_href(href: str) -> str:
+    """ Make sure the href doesn't start or end with a / """
+    if href[0] == "/":
+        href = href[1:]
+    if href[-1] == "/":
+        href = href[:-1]
+    return href
+
 def section_links(parent_entry: element.Tag, list_entry: element.Tag) -> dict:
     section_result = []
     for child in list_entry.children:
@@ -9,7 +17,7 @@ def section_links(parent_entry: element.Tag, list_entry: element.Tag) -> dict:
     return {
                 "type": "expandable-link-group",
                 "text": parent_entry.contents[0].contents[0],
-                "href": parent_entry.contents[0]["href"],
+                "href": clean_href(parent_entry.contents[0]["href"]),
                 "items": section_result
             }
 
@@ -20,7 +28,7 @@ def convert_tag_to_link(item_entry: element.Tag) -> dict:
     return {
             "type": "link",
             "text": a_tag.contents[0],
-            "href": a_tag["href"]
+            "href": clean_href(a_tag["href"])
         }
 
 def convert_nav_html_to_json(html: str) -> list:

--- a/sphinxcontrib/serializinghtml/nav_html_to_json.py
+++ b/sphinxcontrib/serializinghtml/nav_html_to_json.py
@@ -39,24 +39,25 @@ def convert_nav_html_to_json(html: str) -> list:
     ul = soup.ul
     pending_divider = False
     # Iterate through list items
-    for child in ul.children:
-        if type(child) is element.Tag and child.name == "li":
-            # Is there a new unordered list within this section?
-            section = child.find_all("ul", limit=1)
-            if section != []:
-                # Yes, there is, so we have a sub-section. If we've got some content
-                # already, add a divider.
-                if result != []:
-                    result.append({ "type": "divider" })
-                # Now append the current page and the section links. The
-                # ul tag is the only child returned, hence [0]
-                result.append(section_links(child, section[0]))
-                # If there are any "normal" entries after this section
-                # add a divider first
-                pending_divider = True
-            else:
-                if pending_divider:
-                    result.append({ "type": "divider" })
-                    pending_divider = False
-                result.append(convert_tag_to_link(child))
+    if ul is not None:
+        for child in ul.children:
+            if type(child) is element.Tag and child.name == "li":
+                # Is there a new unordered list within this section?
+                section = child.find_all("ul", limit=1)
+                if section != []:
+                    # Yes, there is, so we have a sub-section. If we've got some content
+                    # already, add a divider.
+                    if result != []:
+                        result.append({ "type": "divider" })
+                    # Now append the current page and the section links. The
+                    # ul tag is the only child returned, hence [0]
+                    result.append(section_links(child, section[0]))
+                    # If there are any "normal" entries after this section
+                    # add a divider first
+                    pending_divider = True
+                else:
+                    if pending_divider:
+                        result.append({ "type": "divider" })
+                        pending_divider = False
+                    result.append(convert_tag_to_link(child))
     return result

--- a/sphinxcontrib/serializinghtml/nav_html_to_json.py
+++ b/sphinxcontrib/serializinghtml/nav_html_to_json.py
@@ -1,0 +1,54 @@
+from bs4 import BeautifulSoup, element
+import json
+
+def section_links(parent_entry: element.Tag, list_entry: element.Tag) -> dict:
+    section_result = []
+    for child in list_entry.children:
+        if type(child) is element.Tag and child.name == "li":
+            section_result.append(convert_tag_to_link(child))
+    return {
+                "type": "expandable-link-group",
+                "text": parent_entry.contents[0].contents[0],
+                "href": parent_entry.contents[0]["href"],
+                "items": section_result
+            }
+
+
+def convert_tag_to_link(item_entry: element.Tag) -> dict:
+    # The a tag is a child of the li tag
+    a_tag = item_entry.contents[0]
+    return {
+            "type": "link",
+            "text": a_tag.contents[0],
+            "href": a_tag["href"]
+        }
+
+def convert_nav_html_to_json(html: str) -> list:
+    result = []
+    soup = BeautifulSoup(html, "html.parser")
+
+    # Start with the unordered list
+    ul = soup.ul
+    pending_divider = False
+    # Iterate through list items
+    for child in ul.children:
+        if type(child) is element.Tag and child.name == "li":
+            # Is there a new unordered list within this section?
+            section = child.find_all("ul", limit=1)
+            if section != []:
+                # Yes, there is, so we have a sub-section. If we've got some content
+                # already, add a divider.
+                if result != []:
+                    result.append({ "type": "divider" })
+                # Now append the current page and the section links. The
+                # ul tag is the only child returned, hence [0]
+                result.append(section_links(child, section[0]))
+                # If there are any "normal" entries after this section
+                # add a divider first
+                pending_divider = True
+            else:
+                if pending_divider:
+                    result.append({ "type": "divider" })
+                    pending_divider = False
+                result.append(convert_tag_to_link(child))
+    return result


### PR DESCRIPTION
Add a new configuration section. This is a dictionary that maps from the external full link to the internal relative link. That will get added to a repo's configuration when a doc repo is built for the hub.

Add a new function that looks at all of the `a` tags on a page, trying to match against a mapping link and, if found, replacing it with the local link & removing the trailing `.html`
